### PR TITLE
fix: add directive did not work for XmlDocument

### DIFF
--- a/src/Yaapii.Xml.Xembly/Directive/AddDirective.cs
+++ b/src/Yaapii.Xml.Xembly/Directive/AddDirective.cs
@@ -27,12 +27,16 @@ namespace Yaapii.Xml.Xembly
             var targets = new List<XmlNode>();
             string label = this._name.Raw();
             XmlDocument doc;
-            if(dom.OwnerDocument == null)
+
+            if(dom is XmlDocument)
+            {
+                doc = dom as XmlDocument;
+
+            } else if(dom.OwnerDocument == null)
             {
                 doc = new XmlDocument();
                 doc.AppendChild(dom);
-            }
-            else
+            } else
             {
                 doc = dom.OwnerDocument;
             }

--- a/tests/Yaapii.Xml.Xembly.Tests/Directive/AddDirectiveTest.cs
+++ b/tests/Yaapii.Xml.Xembly.Tests/Directive/AddDirectiveTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using Xunit;
+using Yaapii.Atoms.List;
+using Yaapii.Atoms.Text;
+
+namespace Yaapii.Xml.Xembly.Tests.Directive
+{
+    public class AddDirectiveTest
+    {
+        [Fact]
+        public void AddNodesToCurrentNodes()
+        {
+            Assert.True(
+                    new Xembler(
+                        new EnumerableOf<IDirective>(
+                                new AddDirective("root"),
+                                new AddDirective("item")
+                            )).Dom().InnerXml == "<root><item /></root>","Add Directive failed");
+        }
+
+        [Fact]
+        public void AddNodesToXmlDocument()
+        {
+            Assert.True(
+            new Xembler(
+                    new EnumerableOf<IDirective>(
+                            new AddDirective("root"),
+                            new AddDirective("item")
+                        )).Apply(new XmlDocument()).InnerXml == "<root><item /></root>","Add Directive failed");
+        }
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#22 

### What is the new behavior?
AddDirective works on either XmlDocument and XmlNode

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information