### PR TITLE
Handels XPath with absolute path correctly

### DIFF
--- a/src/Yaapii.Xml.Xambly/Directive/RemoveDirective.cs
+++ b/src/Yaapii.Xml.Xambly/Directive/RemoveDirective.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System.Xml;
 using Yaapii.Atoms.Error;
+using Yaapii.Xml.Xambly.Cursor;
 using Yaapii.Xml.Xambly.Error;
 
 namespace Yaapii.Xml.Xambly
@@ -90,7 +91,7 @@ namespace Yaapii.Xml.Xambly
                 parents.Add(parent);
             }
 
-            return cursor;
+            return new DomCursor(parents);
         }
     }
 }

--- a/src/Yaapii.Xml.Xambly/Directive/XpathDirective.cs
+++ b/src/Yaapii.Xml.Xambly/Directive/XpathDirective.cs
@@ -85,22 +85,6 @@ namespace Yaapii.Xml.Xambly
             IEnumerable<XmlNode> targets;
             string query = SingleQuoted(this._expr.Raw());
 
-            // CSA: Not working in this version. Use only traditional function.
-            //if (ROOT_ONLY.IsMatch(query))
-            //{
-            //    targets = this.RootOnly(ROOT_ONLY.Match(query).Groups[1].Value, dom);
-            //}
-            //else
-            //{
-            //    targets = this.Traditional(query, dom, cursor);
-            //}
-
-            // CSA: This fork is only needed if the cursor points to an XmlNode which is not existing in the dom. 
-            //      In this case the Xpath should work if it contains an absolute path.
-            // Node: The Traditional (XmlNode.SelectNodes(query)) can hadle absolute XPath's also if the cursor points to any child node in the dom. 
-            //       It fails if the cursor points to an stranger node which is not part of the dom.
-            // Update: This fork is not directly needed absolutely anymore. It comes from an undetected bug in the RemoveDirective (after deleting the cursor points to the deleted nodes and not to the parents).
-            //         But i thik the class is more robust with this behaviour and i do not want to delete the code and tests here.
             if (AbsoluteXPath(query))
             {
                 targets =

--- a/tests/Yaapii.Xml.Xambly.Tests/Directive/DirectivesTest.cs
+++ b/tests/Yaapii.Xml.Xambly.Tests/Directive/DirectivesTest.cs
@@ -85,8 +85,11 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
         /// <summary>
         /// Directives can add map of values.
         /// </summary>
-        [Fact]
-        public void AddsMapOfValues()
+        [Theory]
+        [InlineData("/root/first[.=1]")]
+        [InlineData("/root/second[.='two']")]
+        [InlineData("/root/third")]
+        public void AddsMapOfValues(string testXPath)
         {
             var dom = new XmlDocument();
             dom.AppendChild(dom.CreateElement("root"));
@@ -96,14 +99,13 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
                     .Xpath("//root")
                     .Add(
                         new Dictionary<String, Object>() {
-                            { "first", 1 },{ "second", "two" }
+                            { "first", 1 },
+                            { "second", "two" }
                         })
                     .Add("third")
                 ).Apply(dom).InnerXml;
 
-            Assert.True(FromXPath(xml, "/root/first[.=1]") != null);
-            Assert.True(FromXPath(xml, "/root/second[.='two']") != null);
-            Assert.True(FromXPath(xml, "/root/second[.='two']") != null);
+            Assert.True(FromXPath(xml, testXPath) != null);
         }
 
         /// <summary>

--- a/tests/Yaapii.Xml.Xambly.Tests/Directive/DirectivesTest.cs
+++ b/tests/Yaapii.Xml.Xambly.Tests/Directive/DirectivesTest.cs
@@ -296,6 +296,29 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
                 new Yaapii.Atoms.Enumerable.LengthOf(dirs).Value() == 6);
         }
 
+        /// <summary>
+        /// An absolute XPath should set the cursor successfully.
+        /// </summary>
+        [Fact]
+        public void NavigatesFromRootAfterDeletedNode()
+        {
+            var xml = new XmlDocument();
+            xml.Load(new InputOf("<root><child name='Jerome'><property name='test'/></child></root>").Stream());
+            var xambler =
+                new Xambler(
+                    new Directives()
+                        .Xpath("/root/child[@name='Jerome']/property[@name='test']")
+                        .Remove()   // Node will be deleted. After this operation the cursor points to the parent nodes.
+                        .Xpath("/root/child[@name='Jerome']")
+                        .Add("property")
+                        .Attr("name", "test2")
+                ).Apply(xml);
+
+            Assert.Equal(
+                "<root><child name=\"Jerome\"><property name=\"test2\" /></child></root>",
+                xambler.OuterXml
+            );
+        }
 
         /// <summary>
         /// A navigator from an Xml and XPath

--- a/tests/Yaapii.Xml.Xambly.Tests/Directive/DirectivesTest.cs
+++ b/tests/Yaapii.Xml.Xambly.Tests/Directive/DirectivesTest.cs
@@ -18,8 +18,10 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
         /// <summary>
         /// Directives can make a document
         /// </summary>
-        [Fact]
-        public void MakesXmlDocument()
+        [Theory]
+        [InlineData("/page[@the-name]")]
+        [InlineData("/page/big-text[normalize-space(.)='<<hello!!!>>']")]
+        public void MakesXmlDocument(string testXPath)
         {
             string xml =
                 new Xambler(
@@ -31,8 +33,7 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
                         .Add("big-text").Cdata("<<hello!!!>>").Up()
                 ).Xml();
 
-            Assert.NotNull(FromXPath(xml, "/page[@the-name]"));
-            Assert.NotNull(FromXPath(xml, "/page/big-text[normalize-space(.)='<<hello!!!>>']"));
+            Assert.NotNull(FromXPath(xml, testXPath));
         }
 
         /// <summary>
@@ -179,10 +180,15 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
         [Fact]
         public void AddsElementsCaseSensitively()
         {
-            var xml = new Xambler(new Directives().Add("XHtml").AddIf("Body")).Xml();
+            var xml = 
+                new Xambler(
+                    new Directives()
+                        .Add("XHtml")
+                        .AddIf("Body")
+                ).Xml();
             Assert.True(
-                 xml == "<?xml version=\"1.0\" encoding=\"utf-16\"?><XHtml><Body /></XHtml>"
-                );
+                xml == "<?xml version=\"1.0\" encoding=\"utf-16\"?><XHtml><Body /></XHtml>"
+            );
         }
 
         /// <summary>
@@ -200,31 +206,32 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
             var xml = dirs.ToString();
 
             Assert.True(
-                new Regex("ADD \"HELLO\";").Matches(xml).Count == 10);
+                new Regex("ADD \"HELLO\";").Matches(xml).Count == 10
+            );
         }
 
         /// <summary>
         /// Directives can push and pop
         /// </summary>
-        [Fact]
-        public void PushesAndPopsCursor()
+        [Theory]
+        [InlineData("/jeff/lebowski[@birthday]")]
+        [InlineData("/jeff/los-angeles")]
+        [InlineData("/jeff/dude")]
+        public void PushesAndPopsCursor(string testXPath)
         {
-            var xml = new Xambler(
-                             new Directives()
-                                 .Add("jeff")
-                                 .Push().Add("lebowski")
-                                 .Push().Xpath("/jeff").Add("dude").Pop()
-                                 .Attr("birthday", "today").Pop()
-                                 .Add("los-angeles")
-                       ).Xml();
+            var xml = 
+                new Xambler(
+                    new Directives()
+                        .Add("jeff")
+                        .Push().Add("lebowski")
+                        .Push().Xpath("/jeff").Add("dude").Pop()
+                        .Attr("birthday", "today").Pop()
+                        .Add("los-angeles")
+                ).Xml();
 
             Assert.True(
-                null != FromXPath(
-                    xml, "/jeff/lebowski[@birthday]") &&
-                null != FromXPath(
-                    xml, "/jeff/los-angeles") &&
-                null != FromXPath(
-                    xml, "/jeff/dude"));
+                null != FromXPath(xml, testXPath)
+            );
         }
 
         /// <summary>

--- a/tests/Yaapii.Xml.Xambly.Tests/Directive/RemoveDirectiveTest.cs
+++ b/tests/Yaapii.Xml.Xambly.Tests/Directive/RemoveDirectiveTest.cs
@@ -22,7 +22,7 @@
 
 using System.Xml;
 using Xunit;
-using Yaapii.Atoms.List;
+using Yaapii.Atoms.Enumerable;
 using Yaapii.Xml.Xambly.Cursor;
 using Yaapii.Xml.Xambly.Stack;
 
@@ -34,14 +34,16 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
         public void RemoveCurrentNode() {
 
             Assert.True(
-            new Xambler(
-                new Yaapii.Atoms.Enumerable.EnumerableOf<IDirective>(
-                    new AddDirective("root"),
-                    new AddDirective("foobar"),
-                    new RemoveDirective()
-                )).Apply(
+                new Xambler(
+                    new Yaapii.Atoms.Enumerable.EnumerableOf<IDirective>(
+                        new AddDirective("root"),
+                        new AddDirective("foobar"),
+                        new RemoveDirective()
+                    )
+                ).Apply(
                     new XmlDocument()
-                    ).InnerXml == "<root></root>", "Remove node failed");
+                ).InnerXml == "<root></root>", "Remove node failed"
+            );
         }
 
         [Fact]
@@ -52,9 +54,10 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
                         new Yaapii.Atoms.Enumerable.EnumerableOf<IDirective>(
                             new AddDirective("root"),
                             new RemoveDirective()
-                        )).Apply(
-                            new XmlDocument()
-                            );
+                        )
+                    ).Apply(
+                        new XmlDocument()
+                    );
                 }
             );
         }
@@ -63,14 +66,15 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
         public void ThrowsExceptionOnRemoveDocumentNode()
         {
             Assert.Throws<ImpossibleModificationException>(() =>
-            {
-                new Xambler(
-                    new Yaapii.Atoms.Enumerable.EnumerableOf<IDirective>(
-                        new RemoveDirective()
-                    )).Apply(
+                {
+                    new Xambler(
+                        new Yaapii.Atoms.Enumerable.EnumerableOf<IDirective>(
+                            new RemoveDirective()
+                        )
+                    ).Apply(
                         new XmlDocument()
-                        );
-            }
+                    );
+                }
             );
         }
 
@@ -94,6 +98,34 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
 
             Assert.True(
                 dom.InnerXml == "<root><b /></root>", "Remove directive failed"
+            );
+        }
+
+        [Fact]
+        public void CursorPointsToParents()
+        {
+            var dom = new XmlDocument();
+            var root = dom.CreateElement("root");
+            var first = dom.CreateElement("a");
+            var firstChild = dom.CreateElement("a_child");
+            first.AppendChild(firstChild);
+            root.AppendChild(first);
+            var second = dom.CreateElement("b");
+            var secondChild = dom.CreateElement("b_child");
+            second.AppendChild(secondChild);
+            root.AppendChild(second);
+
+            dom.AppendChild(root);
+
+            var cursor =
+                new RemoveDirective().Exec(
+                    dom,
+                    new DomCursor(new EnumerableOf<XmlNode>(firstChild, secondChild)),
+                    new DomStack()
+                );
+            Assert.Equal(
+                new EnumerableOf<XmlNode>(first, second),
+                cursor
             );
         }
     }

--- a/tests/Yaapii.Xml.Xambly.Tests/Directive/XpathDirectiveTests.cs
+++ b/tests/Yaapii.Xml.Xambly.Tests/Directive/XpathDirectiveTests.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Xml;
 using System.Xml.XPath;
 using Xunit;
+using Yaapii.Atoms.Enumerable;
+using Yaapii.Atoms.IO;
 using Yaapii.Xml.Xambly.Cursor;
 using Yaapii.Xml.Xambly.Stack;
 
@@ -143,6 +145,50 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
             ).Apply(clone);
             Assert.NotNull(
                 FromXPath(clone.InnerXml.ToString(), "/high/boom-5")
+            );
+        }
+
+        [Fact]
+        public void NavigatesFromRoot()
+        {
+            var dom = new XmlDocument();
+            var root = dom.CreateElement("root");
+            var first = dom.CreateElement("child");
+            root.AppendChild(first);
+            dom.AppendChild(root);
+
+            Assert.Contains(
+                first,
+                new XpathDirective(
+                    "/root/child"
+                ).Exec(
+                    dom,
+                    new DomCursor(new EnumerableOf<XmlNode>(first)),
+                    new DomStack()
+                )
+            );
+        }
+
+        [Fact]
+        public void NavigatesFromRootWithStrangerCursor()
+        {
+            var dom = new XmlDocument();
+            var root = dom.CreateElement("root");
+            var first = dom.CreateElement("child");
+            root.AppendChild(first);
+            dom.AppendChild(root);
+            // this element doesn't belongs to the dom!
+            var strangerCursor = dom.CreateElement("deleted");
+
+            Assert.Contains(
+                first,
+                new XpathDirective(
+                    "/root/child"
+                ).Exec(
+                    dom,
+                    new DomCursor(new EnumerableOf<XmlNode>(strangerCursor)),
+                    new DomStack()
+                )
             );
         }
 

--- a/tests/Yaapii.Xml.Xambly.Tests/Directive/XpathDirectiveTests.cs
+++ b/tests/Yaapii.Xml.Xambly.Tests/Directive/XpathDirectiveTests.cs
@@ -13,23 +13,29 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
         /// <summary>
         /// XpathDirective can find nodes.
         /// </summary>
-        [Fact]
-        public void FindsNodesWithXpathExpression()
+        [Theory]
+        [InlineData("/root/foo[@bar=1]/test")]
+        [InlineData("/root/bar")]
+        public void FindsNodesWithXpathExpression(string testXPath)
         {
             var dom = new XmlDocument();
 
             new Xambler(
                 new Directives(
-                    "ADD 'root'; ADD 'foo'; ATTR 'bar', '1'; UP; ADD 'bar';")).Apply(dom);
+                    "ADD 'root'; ADD 'foo'; ATTR 'bar', '1'; UP; ADD 'bar';"
+                )
+            ).Apply(dom);
             new Xambler(
                 new Directives(
-                    "XPATH '//*[@bar=1]'; ADD 'test';")).Apply(dom);
+                    "XPATH '//*[@bar=1]'; ADD 'test';"
+                )
+            ).Apply(dom);
 
             Assert.True(
                 null != FromXPath(
-                    dom.InnerXml.ToString(), "/root/foo[@bar=1]/test") &&
-                null != FromXPath(
-                    dom.InnerXml.ToString(), "/root/bar")
+                    dom.InnerXml.ToString(),
+                    testXPath
+                )
             );
         }
 
@@ -44,7 +50,9 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
 
             new Xambler(
                 new Directives(
-                    "XPATH '/nothing'; XPATH '/top'; STRICT '1'; ADD 'hey';")).Apply(dom);
+                    "XPATH '/nothing'; XPATH '/top'; STRICT '1'; ADD 'hey';"
+                )
+            ).Apply(dom);
             Assert.NotNull(FromXPath(dom.InnerXml.ToString(), "/top/hey"));
         }
 
@@ -68,10 +76,11 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
                 .Exec(
                     dom,
                     new DomCursor(
-                        new Yaapii.Atoms.Enumerable.EnumerableOf<XmlNode>(
-                            first)),
-                    new DomStack())
-                );
+                        new Atoms.Enumerable.EnumerableOf<XmlNode>(first)
+                    ),
+                    new DomStack()
+                )
+            );
         }
 
         /// <summary>
@@ -87,8 +96,11 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
                     "/some-root").Exec(
                     dom,
                     new DomCursor(
-                        new Yaapii.Atoms.Enumerable.EnumerableOf<XmlNode>()),
-                    new DomStack()));
+                        new Atoms.Enumerable.EnumerableOf<XmlNode>()
+                    ),
+                    new DomStack()
+                )
+            );
         }
 
         [Fact]
@@ -96,7 +108,9 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
         {
             var dom = new XmlDocument();
 
-            new Xambler(new Directives().Add("Tags").Add("Tag").Set("Transient")).Apply(dom);
+            new Xambler(
+                new Directives().Add("Tags").Add("Tag").Set("Transient")
+            ).Apply(dom);
             
 
             Assert.NotEmpty(
@@ -104,8 +118,11 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
                     "//Tag[contains(.,'Transient')]").Exec(
                     dom,
                     new DomCursor(
-                        new Yaapii.Atoms.Enumerable.EnumerableOf<XmlNode>(dom)),
-                    new DomStack()));
+                        new Atoms.Enumerable.EnumerableOf<XmlNode>(dom)
+                    ),
+                    new DomStack()
+                )
+            );
         }
 
         /// <summary>
@@ -121,19 +138,21 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
             var clone = dom.CloneNode(true);
             new Xambler(
                 new Directives(
-                    "XPATH '/*'; STRICT '1'; ADD 'boom-5';")).Apply(clone);
+                    "XPATH '/*'; STRICT '1'; ADD 'boom-5';"
+                )
+            ).Apply(clone);
             Assert.NotNull(
-                FromXPath(clone.InnerXml.ToString(), "/high/boom-5"));
+                FromXPath(clone.InnerXml.ToString(), "/high/boom-5")
+            );
         }
 
-    #region Helper
-    /// <summary>
-    /// A navigator from an Xml and XPath
-    /// </summary>
-    /// <param name="xml"></param>
-    /// <param name="xpath"></param>
-    /// <returns></returns>
-    private XPathNavigator FromXPath(string xml, string xpath)
+        /// <summary>
+        /// A navigator from an Xml and XPath
+        /// </summary>
+        /// <param name="xml"></param>
+        /// <param name="xpath"></param>
+        /// <returns></returns>
+        private XPathNavigator FromXPath(string xml, string xpath)
         {
             var nav =
                 new XPathDocument(
@@ -172,6 +191,5 @@ namespace Yaapii.Xml.Xambly.Directive.Tests
 
             return result;
         }
-        #endregion Helper
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#100 

### What is the new behavior?
The `XpathDirective()` is more robust an handles absolute XPath expressions by an given illegal cursor.
The `RemoveDirective()` returns cursors to the parents now.

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information
closes #100 