### PR TITLE
CopyOfDirective accepts a XML document now

### DIFF
--- a/src/Yaapii.Xambly/Directive/CopyOfDirective.cs
+++ b/src/Yaapii.Xambly/Directive/CopyOfDirective.cs
@@ -117,10 +117,13 @@ namespace Yaapii.Xml.Xambly.Directive
         {
             var dirs = new Directives();
             var node = _node.Value();
-            dirs.Add(node.Name);
-            foreach (XmlAttribute attr in node.Attributes)
+            if (node.NodeType == XmlNodeType.Element)
             {
-                dirs.Attr(attr.Name, attr.Value);
+                dirs.Add(node.Name);
+                foreach (XmlAttribute attr in node.Attributes)
+                {
+                    dirs.Attr(attr.Name, attr.Value);
+                }
             }
 
             foreach (XmlNode child in node.ChildNodes)

--- a/tests/Yaapii.Xambly.Tests/Directive/CopyOfTest.cs
+++ b/tests/Yaapii.Xambly.Tests/Directive/CopyOfTest.cs
@@ -12,33 +12,58 @@ namespace Yaapii.Xml.Xambly.Tests.Directive
         public void CopiesExistingNode()
         {
             var dom = new XmlDocument();
-            var content = new JoinedText(
-                            "",
-                            "<jeff name='Jeffrey'><first/><second/>",
-                            "<?some-pi test?>",
-                            "<file a='x'><f><name>\u20ac</name></f></file>",
-                            "<!-- some comment -->",
-                            "<x><![CDATA[hey you]]></x>  </jeff>");
+            var content = 
+                new JoinedText(
+                    "",
+                    "<jeff name='Jeffrey'><first/><second/>",
+                    "<?some-pi test?>",
+                    "<file a='x'><f><name>\u20ac</name></f></file>",
+                    "<!-- some comment -->",
+                    "<x><![CDATA[hey you]]></x>  </jeff>"
+                );
             var xml = new XmlDocument();
             xml.LoadXml(content.AsString());
             new Xambler(
                 new Directives()
-                        .Add("dudes")
-                        .Append(new CopyOfDirective(xml.DocumentElement))).Apply(dom);
+                    .Add("dudes")
+                    .Append(new CopyOfDirective(xml.DocumentElement)
+                )
+            ).Apply(dom);
 
             Assert.True(
-                    new LengthOf(dom.SelectNodes("/dudes/jeff[@name = 'Jeffrey']")).Value() > 0 &&
-                    new LengthOf(dom.SelectNodes("/dudes/jeff[first and second]")).Value() > 0 &&
-                    new LengthOf(dom.SelectNodes("/dudes/jeff/file[@a='x']/f[name='\u20ac']")).Value() > 0
-                );
+                new LengthOf(dom.SelectNodes("/dudes/jeff[@name = 'Jeffrey']")).Value() > 0 &&
+                new LengthOf(dom.SelectNodes("/dudes/jeff[first and second]")).Value() > 0 &&
+                new LengthOf(dom.SelectNodes("/dudes/jeff/file[@a='x']/f[name='\u20ac']")).Value() > 0
+            );
         }
 
-        [Fact(Skip = "true")]
+        [Fact]
         public void CopyOfXmlDocument()
         {
-            var doc = new XmlDocument();
-            var dirs = new CopyOfDirective(doc);
-            var xml = new Xambler(dirs).Xml();
+            var dom = new XmlDocument();
+            var content =
+                new JoinedText(
+                    "",
+                    "<jeff name='Jeffrey'><first/><second/>",
+                    "<?some-pi test?>",
+                    "<file a='x'><f><name>\u20ac</name></f></file>",
+                    "<!-- some comment -->",
+                    "<x><![CDATA[hey you]]></x>  </jeff>"
+                );
+            var xml = new XmlDocument();
+            xml.LoadXml(content.AsString());
+            new Xambler(
+                new Directives()
+                    .Add("dudes")
+                    .Append(new CopyOfDirective(xml)
+                )
+            ).Apply(dom);
+
+            Assert.True(
+                new LengthOf(dom.SelectNodes("/dudes/jeff[@name = 'Jeffrey']")).Value() > 0 &&
+                new LengthOf(dom.SelectNodes("/dudes/jeff[first and second]")).Value() > 0 &&
+                new LengthOf(dom.SelectNodes("/dudes/jeff/file[@a='x']/f[name='\u20ac']")).Value() > 0
+            );
         }
     }
 }

--- a/tests/Yaapii.Xambly.Tests/Directive/CopyOfTest.cs
+++ b/tests/Yaapii.Xambly.Tests/Directive/CopyOfTest.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Xml;
-using System.Xml.Linq;
+﻿using System.Xml;
 using Xunit;
 using Yaapii.Atoms.Enumerable;
 using Yaapii.Atoms.Text;
@@ -35,7 +31,14 @@ namespace Yaapii.Xml.Xambly.Tests.Directive
                     new LengthOf(dom.SelectNodes("/dudes/jeff[first and second]")).Value() > 0 &&
                     new LengthOf(dom.SelectNodes("/dudes/jeff/file[@a='x']/f[name='\u20ac']")).Value() > 0
                 );
+        }
 
+        [Fact(Skip = "true")]
+        public void CopyOfXmlDocument()
+        {
+            var doc = new XmlDocument();
+            var dirs = new CopyOfDirective(doc);
+            var xml = new Xambler(dirs).Xml();
         }
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#114 

### What is the new behavior?
The `CopyOfDirective()` can handle `XmlDocument()` now.
No null pointer exception is thrown anymore.

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information